### PR TITLE
allow console to call functions with numbers

### DIFF
--- a/apps/playground/src/console-parser.ts
+++ b/apps/playground/src/console-parser.ts
@@ -25,7 +25,7 @@ const separated = <T>(
 
 const functionCall = map(
   seq(
-    regexp(/[a-zA-Z]+/),
+    regexp(/[a-zA-Z0-9!#$%&'*+\-\./:<=>?@\\\^_`|~]+/),
     token("\\("),
     opt(separated(number, ",")),
     token("\\)")

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "author": "ryohey",
   "license": "MIT",
   "devDependencies": {
+    "esbuild": "^0.25.2",
+    "rollup": "^4.36.0",
     "prettier": "^3.5.3",
     "turbo": "^2.4.4"
   },


### PR DESCRIPTION
Hey,

I think this helps with solving issue #12 .

The problem likely wasn't related to the number of arguments being passed, but rather to the way functions were being called.

After some investigation, I found that the console parser wasn't allowing numbers and symbols in function names, even though it should have (see [documentation](https://webassembly.github.io/spec/core/text/values.html#text-id)).

Previously, if I had two functions named `foo` and `foo2`, the parser would only recognize `foo`, ignoring any trailing numbers or symbols. As so, calling `foo2` would actually call `foo`. I believe this is now working correctly.


I also added some packages into package.json that fixed one or 2 error  I had.

All the best,
Joao
